### PR TITLE
Unassign Tasks to Persons

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AssignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignCommand.java
@@ -46,21 +46,32 @@ public class AssignCommand extends Command {
         this.personIndex = personIndex;
     }
 
-    @Override
-    public CommandResult execute(Model model) throws CommandException {
+    private Task getTaskToAssign(Model model) throws CommandException {
+        // TODO: change to use filtered list instead
         List<Task> lastShownTaskList = model.getTaskList().getSerializeTaskList();
-        List<Person> lastShownPersonList = model.getFilteredPersonList();
 
         if (taskIndex.getZeroBased() >= lastShownTaskList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
         }
 
+        return lastShownTaskList.get(taskIndex.getZeroBased());
+    }
+
+    private Person getPersonToBeAssigned(Model model) throws CommandException {
+        List<Person> lastShownPersonList = model.getFilteredPersonList();
+
         if (personIndex.getZeroBased() >= lastShownPersonList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
-        Person personToBeAssigned = lastShownPersonList.get(personIndex.getZeroBased());
-        Task taskToAssign = lastShownTaskList.get(taskIndex.getZeroBased());
+        return lastShownPersonList.get(personIndex.getZeroBased());
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        Task taskToAssign = getTaskToAssign(model);
+        Person personToBeAssigned = getPersonToBeAssigned(model);
+
         Person assignedPerson = personToBeAssigned.addTask(taskToAssign);
 
         model.setPerson(personToBeAssigned, assignedPerson);

--- a/src/main/java/seedu/address/logic/commands/UnassignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnassignCommand.java
@@ -1,0 +1,16 @@
+package seedu.address.logic.commands;
+
+import seedu.address.model.Model;
+
+/**
+ * Unassigns an existing task to an existing person in the address book.
+ */
+public class UnassignCommand extends Command {
+
+    public static final String COMMAND_WORD = "unassign";
+
+    @Override
+    public CommandResult execute(Model model) {
+        return new CommandResult("Hello from unassign");
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/UnassignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnassignCommand.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 
 /**
@@ -9,8 +10,22 @@ public class UnassignCommand extends Command {
 
     public static final String COMMAND_WORD = "unassign";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Unassigns the task identified "
+            + "by the index number used in the last task listing "
+            + "to the person identified "
+            + "by the index number used in the last person listing. "
+            + "Does nothing if the task not assigned to the person.\n"
+            + "Parameters: TASK_INDEX (must be a positive integer) "
+            + "to/ [PERSON_INDEX (must be a positive integer)]\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + "to/ 2";
+
+    public static final String MESSAGE_NOT_IMPLEMENTED_YET =
+            "Unassign command not implemented yet";
+
     @Override
-    public CommandResult execute(Model model) {
-        return new CommandResult("Hello from unassign");
+    public CommandResult execute(Model model) throws CommandException {
+        throw new CommandException(MESSAGE_NOT_IMPLEMENTED_YET);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/UnassignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnassignCommand.java
@@ -1,5 +1,8 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 
@@ -21,11 +24,41 @@ public class UnassignCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 "
             + "to/ 2";
 
-    public static final String MESSAGE_NOT_IMPLEMENTED_YET =
-            "Unassign command not implemented yet";
+    public static final String MESSAGE_ARGUMENTS = "Task Index: %1$d, Person Index: %2$s";
+
+    private final Index taskIndex;
+    private final Index personIndex;
+
+    /**
+     * @param taskIndex of the task in the filtered task list to be unassigned to the person
+     * @param personIndex of the person in the filtered person list to be unassigned the task
+     */
+    public UnassignCommand(Index taskIndex, Index personIndex) {
+        requireAllNonNull(taskIndex, personIndex);
+
+        this.taskIndex = taskIndex;
+        this.personIndex = personIndex;
+    }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        throw new CommandException(MESSAGE_NOT_IMPLEMENTED_YET);
+        throw new CommandException(
+                String.format(MESSAGE_ARGUMENTS, taskIndex.getOneBased(), personIndex.getOneBased()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof UnassignCommand)) {
+            return false;
+        }
+
+        UnassignCommand e = (UnassignCommand) other;
+        return taskIndex.equals(e.taskIndex)
+                && personIndex.equals(e.personIndex);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -91,7 +91,7 @@ public class AddressBookParser {
             return new AssignCommandParser().parse(arguments);
 
         case UnassignCommand.COMMAND_WORD:
-            return new UnassignCommand();
+            return new UnassignCommandParser().parse(arguments);
 
         case MarkTaskCommand.COMMAND_WORD:
             return new MarkTaskCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -22,6 +22,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListTaskCommand;
 import seedu.address.logic.commands.MarkTaskCommand;
+import seedu.address.logic.commands.UnassignCommand;
 import seedu.address.logic.commands.UnmarkTaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -88,6 +89,9 @@ public class AddressBookParser {
 
         case AssignCommand.COMMAND_WORD:
             return new AssignCommandParser().parse(arguments);
+
+        case UnassignCommand.COMMAND_WORD:
+            return new UnassignCommand();
 
         case MarkTaskCommand.COMMAND_WORD:
             return new MarkTaskCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/UnassignCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnassignCommandParser.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TO;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.UnassignCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new {@code UnassignCommand} object
+ */
+public class UnassignCommandParser implements Parser<UnassignCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code UnassignCommand}
+     * and returns a {@code UnassignCommand} object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public UnassignCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
+                PREFIX_TO);
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_TO);
+        Index taskIndex;
+        Index personIndex;
+        try {
+            taskIndex = ParserUtil.parseIndex(argMultimap.getPreamble());
+            personIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_TO).orElse(""));
+        } catch (IllegalValueException ive) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    UnassignCommand.MESSAGE_USAGE), ive);
+        }
+
+        return new UnassignCommand(taskIndex, personIndex);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/UnassignCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnassignCommandTest.java
@@ -1,0 +1,128 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalTasks.getTypicalTaskList;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.TaskList;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.task.Task;
+import seedu.address.testutil.PersonBuilder;
+
+class UnassignCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), getTypicalTaskList(), new UserPrefs());
+
+    @Test
+    public void execute_unassignTaskUnfilteredList_success() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST.getZeroBased());
+        Set<Task> editedTasks = new HashSet<>(firstPerson.getTasks());
+        Task taskToUnassign = model.getTaskList().getSerializeTaskList().get(INDEX_FIRST.getZeroBased());
+        editedTasks.remove(taskToUnassign);
+        Person editedPerson = new PersonBuilder(firstPerson).withTasks(editedTasks).build();
+
+        UnassignCommand unassignCommand = new UnassignCommand(INDEX_FIRST, INDEX_FIRST);
+
+        String expectedMessage = String.format(UnassignCommand.MESSAGE_SUCCESS, Messages.formatTask(taskToUnassign),
+                editedPerson.getName());
+
+        Model expectedModel = new ModelManager(
+                new AddressBook(model.getAddressBook()), new TaskList(model.getTaskList()), new UserPrefs());
+        expectedModel.setPerson(firstPerson, editedPerson);
+
+        assertCommandSuccess(unassignCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_filteredList_success() {
+        showPersonAtIndex(model, INDEX_FIRST);
+
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST.getZeroBased());
+        Set<Task> editedTasks = new HashSet<>(firstPerson.getTasks());
+        Task taskToUnassign = model.getTaskList().getSerializeTaskList().get(INDEX_FIRST.getZeroBased());
+        editedTasks.remove(taskToUnassign);
+        Person editedPerson = new PersonBuilder(firstPerson).withTasks(editedTasks).build();
+
+        UnassignCommand unassignCommand = new UnassignCommand(INDEX_FIRST, INDEX_FIRST);
+
+        String expectedMessage = String.format(UnassignCommand.MESSAGE_SUCCESS, Messages.formatTask(taskToUnassign),
+                editedPerson.getName());
+
+        Model expectedModel = new ModelManager(
+                new AddressBook(model.getAddressBook()), new TaskList(model.getTaskList()), new UserPrefs());
+        expectedModel.setPerson(firstPerson, editedPerson);
+
+        assertCommandSuccess(unassignCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidTaskIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getTaskList().getSerializeTaskList().size() + 1);
+        UnassignCommand unassignCommand = new UnassignCommand(outOfBoundIndex, INDEX_FIRST);
+
+        assertCommandFailure(unassignCommand, model, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_invalidPersonIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        UnassignCommand unassignCommand = new UnassignCommand(INDEX_FIRST, outOfBoundIndex);
+
+        assertCommandFailure(unassignCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Edit filtered list where index is larger than size of filtered list,
+     * but smaller than size of address book
+     */
+    @Test
+    public void execute_invalidPersonIndexFilteredList_failure() {
+        showPersonAtIndex(model, INDEX_FIRST);
+        Index outOfBoundIndex = INDEX_SECOND;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        UnassignCommand unassignCommand = new UnassignCommand(INDEX_FIRST, outOfBoundIndex);
+
+        assertCommandFailure(unassignCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        UnassignCommand unassignCommand = new UnassignCommand(INDEX_FIRST, INDEX_FIRST);
+        UnassignCommand unassignOneToTwoCommand = new UnassignCommand(INDEX_FIRST, INDEX_SECOND);
+        UnassignCommand unassignTwoToOneCommand = new UnassignCommand(INDEX_SECOND, INDEX_FIRST);
+
+        // same object -> returns true
+        assertEquals(unassignCommand, unassignCommand);
+
+        // same values -> returns true
+        UnassignCommand unassignCommandCopy = new UnassignCommand(INDEX_FIRST, INDEX_FIRST);
+        assertEquals(unassignCommand, unassignCommandCopy);
+
+        // null -> returns false
+        assertNotEquals(unassignCommand, null);
+
+        // different indices -> returns false
+        assertNotEquals(unassignCommand, unassignOneToTwoCommand);
+        assertNotEquals(unassignCommand, unassignTwoToOneCommand);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -30,6 +30,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListTaskCommand;
 import seedu.address.logic.commands.MarkTaskCommand;
+import seedu.address.logic.commands.UnassignCommand;
 import seedu.address.logic.commands.UnmarkTaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
@@ -99,6 +100,14 @@ public class AddressBookParserTest {
                 AssignCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased() + " "
                 + PREFIX_TO + " " + INDEX_FIRST.getOneBased());
         assertEquals(new AssignCommand(INDEX_FIRST, INDEX_FIRST), command);
+    }
+
+    @Test
+    public void parseCommand_unassign() throws Exception {
+        UnassignCommand command = (UnassignCommand) parser.parseCommand(
+                UnassignCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased() + " "
+                        + PREFIX_TO + " " + INDEX_FIRST.getOneBased());
+        assertEquals(new UnassignCommand(INDEX_FIRST, INDEX_FIRST), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/UnassignCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnassignCommandParserTest.java
@@ -9,22 +9,22 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.Messages;
-import seedu.address.logic.commands.AssignCommand;
+import seedu.address.logic.commands.UnassignCommand;
 
-public class AssignCommandParserTest {
+public class UnassignCommandParserTest {
     private static final String INVALID_TO = " " + PREFIX_TO + "a";
 
     private static final String TO_ONE = " " + PREFIX_TO + "1";
     private static final String TO_TWO = " " + PREFIX_TO + "2";
 
     private static final String MESSAGE_INVALID_FORMAT =
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignCommand.MESSAGE_USAGE);
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnassignCommand.MESSAGE_USAGE);
 
-    private AssignCommandParser parser = new AssignCommandParser();
+    private UnassignCommandParser parser = new UnassignCommandParser();
 
     @Test
     public void parse_validArgs_success() {
-        assertParseSuccess(parser, "1" + TO_ONE, new AssignCommand(INDEX_FIRST, INDEX_FIRST));
+        assertParseSuccess(parser, "1" + TO_ONE, new UnassignCommand(INDEX_FIRST, INDEX_FIRST));
     }
 
     @Test


### PR DESCRIPTION
# The `unassign` Command

The `unassign` command unassigns tasks to people in the address book. The command has the following format:

```
unassign TASK_NUMBER to/ PERSON_NUMBER
```

Parameter: `TASK_NUMBER`

- Must be a numeric string representing a number between 1 and number of tasks.
- If the value is not acceptable, the error message `The task index provided is invalid` is displayed.

Parameter: `PERSON_NUMBER`

- Must be a numeric string representing a number between 1 and number of persons in the filtered person view.
- If the value is not acceptable, the error message `The person index provided is invalid` is displayed.

If the person is already unassigned the task, the command is still accepted and succeeds.

## Things to note

- `TASK_NUMBER` currently refers to the index of the tasks in `TaskList`. We will need to have `TASK_NUMBER` refer to a filtered view of tasks instead.
- UG is to be updated to document the new `unassign` command.


This PR is linked to #41.