### PR TITLE
Clear Tasks of Persons

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearTaskCommand.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 
 /**
@@ -9,8 +10,17 @@ public class ClearTaskCommand extends Command {
 
     public static final String COMMAND_WORD = "cleartask";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Unassigns all tasks assigned to the person identified "
+            + "by the index number used in the last person listing.\n"
+            + "Parameters: PERSON_INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_NOT_IMPLEMENTED_YET =
+            "ClearTask command not implemented yet";
+
     @Override
-    public CommandResult execute(Model model) {
-        return new CommandResult("Hello from cleartask");
+    public CommandResult execute(Model model) throws CommandException {
+        throw new CommandException(MESSAGE_NOT_IMPLEMENTED_YET);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ClearTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearTaskCommand.java
@@ -1,0 +1,16 @@
+package seedu.address.logic.commands;
+
+import seedu.address.model.Model;
+
+/**
+ * Unassigns all tasks assigned to an existing person in the address book.
+ */
+public class ClearTaskCommand extends Command {
+
+    public static final String COMMAND_WORD = "cleartask";
+
+    @Override
+    public CommandResult execute(Model model) {
+        return new CommandResult("Hello from cleartask");
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ClearTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearTaskCommand.java
@@ -1,5 +1,8 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 
@@ -16,11 +19,37 @@ public class ClearTaskCommand extends Command {
             + "Parameters: PERSON_INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_NOT_IMPLEMENTED_YET =
-            "ClearTask command not implemented yet";
+    public static final String MESSAGE_ARGUMENTS = "Index: %1$d";
+
+    private final Index index;
+
+    /**
+     * @param index of the person in the filtered person list to edit the remark
+     */
+    public ClearTaskCommand(Index index) {
+        requireAllNonNull(index);
+
+        this.index = index;
+    }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        throw new CommandException(MESSAGE_NOT_IMPLEMENTED_YET);
+        throw new CommandException(
+                String.format(MESSAGE_ARGUMENTS, index.getOneBased()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ClearTaskCommand)) {
+            return false;
+        }
+
+        ClearTaskCommand e = (ClearTaskCommand) other;
+        return index.equals(e.index);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ClearTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearTaskCommand.java
@@ -1,10 +1,16 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.HashSet;
+import java.util.List;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.Person;
 
 /**
  * Unassigns all tasks assigned to an existing person in the address book.
@@ -19,7 +25,7 @@ public class ClearTaskCommand extends Command {
             + "Parameters: PERSON_INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_ARGUMENTS = "Index: %1$d";
+    public static final String MESSAGE_SUCCESS = "Tasks for %1$s has been cleared.";
 
     private final Index index;
 
@@ -32,10 +38,27 @@ public class ClearTaskCommand extends Command {
         this.index = index;
     }
 
+    private Person getPersonToBeUnassigned(Model model) throws CommandException {
+        List<Person> lastShownPersonList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() >= lastShownPersonList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        return lastShownPersonList.get(index.getZeroBased());
+    }
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        throw new CommandException(
-                String.format(MESSAGE_ARGUMENTS, index.getOneBased()));
+        Person personToBeUnassigned = getPersonToBeUnassigned(model);
+
+        Person unassignedPerson = new Person(personToBeUnassigned.getName(), personToBeUnassigned.getPhone(),
+                personToBeUnassigned.getEmail(), personToBeUnassigned.getAddress(), new HashSet<>());
+
+        model.setPerson(personToBeUnassigned, unassignedPerson);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, unassignedPerson.getName()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddTaskCommand;
 import seedu.address.logic.commands.AssignCommand;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.ClearTaskCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeleteTaskCommand;
@@ -88,6 +89,9 @@ public class AddressBookParser {
 
         case AssignCommand.COMMAND_WORD:
             return new AssignCommandParser().parse(arguments);
+
+        case ClearTaskCommand.COMMAND_WORD:
+            return new ClearTaskCommand();
 
         case MarkTaskCommand.COMMAND_WORD:
             return new MarkTaskCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -91,7 +91,7 @@ public class AddressBookParser {
             return new AssignCommandParser().parse(arguments);
 
         case ClearTaskCommand.COMMAND_WORD:
-            return new ClearTaskCommand();
+            return new ClearTaskCommandParser().parse(arguments);
 
         case MarkTaskCommand.COMMAND_WORD:
             return new MarkTaskCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/ClearTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ClearTaskCommandParser.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.ClearTaskCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new {@code ClearTaskCommand} object
+ */
+public class ClearTaskCommandParser implements Parser<ClearTaskCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code ClearTaskCommand}
+     * and returns a {@code ClearTaskCommand} object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ClearTaskCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(args);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ClearTaskCommand.MESSAGE_USAGE), pe);
+        }
+
+        return new ClearTaskCommand(index);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/ClearTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearTaskCommandTest.java
@@ -1,0 +1,108 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.HashSet;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.TaskList;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code ClearTaskCommand}.
+ */
+public class ClearTaskCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new TaskList(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Person personToUnassign = model.getFilteredPersonList().get(INDEX_FIRST.getZeroBased());
+        Person editedPerson = new Person(personToUnassign.getName(), personToUnassign.getPhone(),
+                personToUnassign.getEmail(), personToUnassign.getAddress(), new HashSet<>());
+
+        ClearTaskCommand clearTaskCommand = new ClearTaskCommand(INDEX_FIRST);
+
+        String expectedMessage = String.format(ClearTaskCommand.MESSAGE_SUCCESS, personToUnassign.getName());
+
+        ModelManager expectedModel = new ModelManager(
+                model.getAddressBook(), new TaskList(model.getTaskList()), new UserPrefs());
+        expectedModel.setPerson(personToUnassign, editedPerson);
+
+        assertCommandSuccess(clearTaskCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        ClearTaskCommand clearTaskCommand = new ClearTaskCommand(outOfBoundIndex);
+
+        assertCommandFailure(clearTaskCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showPersonAtIndex(model, INDEX_FIRST);
+
+        Person personToUnassign = model.getFilteredPersonList().get(INDEX_FIRST.getZeroBased());
+        Person editedPerson = new Person(personToUnassign.getName(), personToUnassign.getPhone(),
+                personToUnassign.getEmail(), personToUnassign.getAddress(), new HashSet<>());
+
+        ClearTaskCommand clearTaskCommand = new ClearTaskCommand(INDEX_FIRST);
+
+        String expectedMessage = String.format(ClearTaskCommand.MESSAGE_SUCCESS, personToUnassign.getName());
+
+        Model expectedModel = new ModelManager(
+                model.getAddressBook(), new TaskList(model.getTaskList()), new UserPrefs());
+        expectedModel.setPerson(personToUnassign, editedPerson);
+
+        assertCommandSuccess(clearTaskCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showPersonAtIndex(model, INDEX_FIRST);
+
+        Index outOfBoundIndex = INDEX_SECOND;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        ClearTaskCommand clearTaskCommand = new ClearTaskCommand(outOfBoundIndex);
+
+        assertCommandFailure(clearTaskCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        ClearTaskCommand clearTaskFirstCommand = new ClearTaskCommand(INDEX_FIRST);
+        ClearTaskCommand clearTaskSecondCommand = new ClearTaskCommand(INDEX_SECOND);
+
+        // same object -> returns true
+        assertEquals(clearTaskFirstCommand, clearTaskFirstCommand);
+
+        // same values -> returns true
+        ClearTaskCommand clearTaskFirstCommandCopy = new ClearTaskCommand(INDEX_FIRST);
+        assertEquals(clearTaskFirstCommand, clearTaskFirstCommandCopy);
+
+        // null -> returns false
+        assertNotEquals(clearTaskFirstCommand, null);
+
+        // different person -> returns false
+        assertNotEquals(clearTaskFirstCommand, clearTaskSecondCommand);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -20,6 +20,7 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddTaskCommand;
 import seedu.address.logic.commands.AssignCommand;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.ClearTaskCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeleteTaskCommand;
 import seedu.address.logic.commands.EditCommand;
@@ -99,6 +100,13 @@ public class AddressBookParserTest {
                 AssignCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased() + " "
                 + PREFIX_TO + " " + INDEX_FIRST.getOneBased());
         assertEquals(new AssignCommand(INDEX_FIRST, INDEX_FIRST), command);
+    }
+
+    @Test
+    public void parseCommand_cleartask() throws Exception {
+        ClearTaskCommand command = (ClearTaskCommand) parser.parseCommand(
+                ClearTaskCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased());
+        assertEquals(new ClearTaskCommand(INDEX_FIRST), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ClearTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ClearTaskCommandParserTest.java
@@ -1,0 +1,25 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ClearTaskCommand;
+
+public class ClearTaskCommandParserTest {
+    private ClearTaskCommandParser parser = new ClearTaskCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsClearTaskCommand() {
+        assertParseSuccess(parser, "1", new ClearTaskCommand(INDEX_FIRST));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, ClearTaskCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
# The `cleartask` Command

The `cleartask` command unassigns all tasks to people in the address book. The command has the following format:

```
cleartask PERSON_NUMBER
```

Parameter: `PERSON_NUMBER`

- Must be a numeric string representing a number between 1 and number of persons in the filtered person view.
- If the value is not acceptable, the error message The person index provided is invalid is displayed.

This PR is linked to #43.