### PR TITLE
Update to developer guide for the model component

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -130,6 +130,14 @@ The `Model` component,
 * stores a `UserPref` object that represents the user’s preferences. This is exposed to the outside as a `ReadOnlyUserPref` objects.
 * does not depend on any of the other three components (as the `Model` represents data entities of the domain, they should make sense on their own without depending on other components)
 
+<box type="info" seamless>
+
+**Note:** An alternative (arguably, a more OOP) model is given below. `TaskList` implements the `ReadOnlyTaskList` interface, and has a `UniqueTaskList` that contains all `Task`s. This allows `TaskList` to be implemented in a way that is consistent to how `AddressBook` is implemented, thus any benefits arising from the design decisions of `Person` also applies to `Task`. We are currently not adopting this model due to time constraints and the benefits are not immediately obvious.<br>
+
+<puml src="diagrams/BetterModelClassDiagram.puml" width="562.5" />
+
+</box>
+
 
 ### Storage component
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -116,25 +116,19 @@ How the parsing works:
 * All `XYZCommandParser` classes (e.g., `AddCommandParser`, `DeleteCommandParser`, ...) inherit from the `Parser` interface so that they can be treated similarly where possible e.g, during testing.
 
 ### Model component
-**API** : [`Model.java`](https://github.com/se-edu/addressbook-level3/tree/master/src/main/java/seedu/address/model/Model.java)
+**API** : [`Model.java`](https://github.com/AY2324S2-CS2103T-W13-4/tp/blob/master/src/main/java/seedu/address/model/Model.java)
 
-<puml src="diagrams/ModelClassDiagram.puml" width="450" />
+<puml src="diagrams/ModelClassDiagram.puml" width="675" />
 
 
 The `Model` component,
 
 * stores the address book data i.e., all `Person` objects (which are contained in a `UniquePersonList` object).
 * stores the currently 'selected' `Person` objects (e.g., results of a search query) as a separate _filtered_ list which is exposed to outsiders as an unmodifiable `ObservableList<Person>` that can be 'observed' e.g. the UI can be bound to this list so that the UI automatically updates when the data in the list change.
+* stores the task list data i.e., all `Task` objects (which are contained in a `TaskList` object).
+* stores the currently 'selected' `Task` objects (e.g., results of a search query) as a separate _filtered_ list which is exposed to outsiders as an unmodifiable `ObservableList<Task>` that can be 'observed' e.g. the UI can be bound to this list so that the UI automatically updates when the data in the list change.
 * stores a `UserPref` object that represents the user’s preferences. This is exposed to the outside as a `ReadOnlyUserPref` objects.
 * does not depend on any of the other three components (as the `Model` represents data entities of the domain, they should make sense on their own without depending on other components)
-
-<box type="info" seamless>
-
-**Note:** An alternative (arguably, a more OOP) model is given below. It has a `Tag` list in the `AddressBook`, which `Person` references. This allows `AddressBook` to only require one `Tag` object per unique tag, instead of each `Person` needing their own `Tag` objects.<br>
-
-<puml src="diagrams/BetterModelClassDiagram.puml" width="450" />
-
-</box>
 
 
 ### Storage component

--- a/docs/diagrams/BetterModelClassDiagram.puml
+++ b/docs/diagrams/BetterModelClassDiagram.puml
@@ -4,18 +4,14 @@ skinparam arrowThickness 1.1
 skinparam arrowColor MODEL_COLOR
 skinparam classBackgroundColor MODEL_COLOR
 
-AddressBook *-right-> "1" UniquePersonList
-AddressBook *-right-> "1" UniqueTagList
-UniqueTagList -[hidden]down- UniquePersonList
-UniqueTagList -[hidden]down- UniquePersonList
+TaskList -up-|> ReadOnlyTaskList
+TaskList *-right-> "1" UniqueTaskList
 
-UniqueTagList -right-> "*" Tag
-UniquePersonList -right-> Person
+UniqueTaskList -right-> "*" Task : all
 
-Person -up-> "*" Tag
-
-Person *--> Name
-Person *--> Phone
-Person *--> Email
-Person *--> Address
+Task *--> TaskName
+Task *--> TaskDescription
+Task *--> TaskPriority
+Task *--> TaskStatus
+Task *--> TaskDeadline
 @enduml

--- a/docs/diagrams/ModelClassDiagram.puml
+++ b/docs/diagrams/ModelClassDiagram.puml
@@ -5,43 +5,53 @@ skinparam arrowColor MODEL_COLOR
 skinparam classBackgroundColor MODEL_COLOR
 
 Package Model as ModelPackage <<Rectangle>>{
-Class "<<interface>>\nReadOnlyAddressBook" as ReadOnlyAddressBook
-Class "<<interface>>\nReadOnlyUserPrefs" as ReadOnlyUserPrefs
 Class "<<interface>>\nModel" as Model
+Class "<<interface>>\nReadOnlyAddressBook" as ReadOnlyAddressBook
+Class TaskList
 Class AddressBook
 Class ModelManager
-Class UserPrefs
 
 Class UniquePersonList
 Class Person
+Class Task
 Class Address
 Class Email
 Class Name
 Class Phone
-Class Tag
+Class TaskName
+Class TaskDescription
+Class TaskPriority
+Class TaskStatus
+Class TaskDeadline
 
 Class I #FFFFFF
 }
 
 Class HiddenOutside #FFFFFF
-HiddenOutside ..> Model
+HiddenOutside .left.> Model
 
-AddressBook .up.|> ReadOnlyAddressBook
+AddressBook .left.|> ReadOnlyAddressBook
 
-ModelManager .up.|> Model
-Model .right.> ReadOnlyUserPrefs
+ModelManager .left.|> Model
 Model .left.> ReadOnlyAddressBook
+Model .right.> TaskList
 ModelManager -left-> "1" AddressBook
-ModelManager -right-> "1" UserPrefs
-UserPrefs .up.|> ReadOnlyUserPrefs
+ModelManager --> "1" TaskList
 
 AddressBook *--> "1" UniquePersonList
-UniquePersonList --> "~* all" Person
+UniquePersonList --> "~*" Person : all
 Person *--> Name
 Person *--> Phone
 Person *--> Email
 Person *--> Address
-Person *--> "*" Tag
+Person *--> "*" Task
+
+TaskList --> "~*" Task : all
+Task *--> TaskName
+Task *--> TaskDescription
+Task *--> TaskPriority
+Task *--> TaskStatus
+Task *--> TaskDeadline
 
 Person -[hidden]up--> I
 UniquePersonList -[hidden]right-> I
@@ -50,5 +60,6 @@ Name -[hidden]right-> Phone
 Phone -[hidden]right-> Address
 Address -[hidden]right-> Email
 
-ModelManager --> "~* filtered" Person
+ModelManager --> "~*" Person : filtered
+ModelManager --> "~*" Task : filtered
 @enduml


### PR DESCRIPTION
Updated the class diagram and its description to reflect the latest integration of `TaskList`. To keep the diagram simple, `UserPrefs` has been omitted from the class diagram as it is less important.

Removed the note on an alternative model as it is no longer relevant. However, depending on the specification of the `AddressBook` class (whether it is responsible for storing only people, or people together with tasks), it might still make sense to maintain the `Task` list in `AddressBook`.

Instead, the following serves as a good alternative model:

Introduce a `ReadOnlyTaskList` interface, which `TaskList` implements. The `TaskList` can then have a `UniqueTaskList` that contains all `Task`s. This model is consistent with how `Person` is implemented, thus any benefits arising from the design decisions of `Person` also applies to `Task`. We are currently not adopting this model due to time constraints and the benefits are not immediately obvious.