### PR TITLE
Tweak Usage Messages

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AssignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignCommand.java
@@ -29,7 +29,7 @@ public class AssignCommand extends Command {
             + "by the index numbers used in the last person listing. "
             + "Does nothing if the task is already assigned to a person.\n"
             + "Parameters: TASK_INDEX (must be a positive integer) "
-            + "to/ PERSON_INDEX [MORE_PERSON_INDICES] (must be distinct positive integers)\n"
+            + "to/ PERSON_INDEX [MORE_PERSON_INDICES] (must be positive integers)\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + "to/ 1 2";
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -21,7 +21,7 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the people identified by the index numbers used in the displayed person list.\n"
-            + "Parameters: INDEX [MORE_INDICES] (must be distinct positive integers)\n"
+            + "Parameters: INDEX [MORE_INDICES] (must be positive integers)\n"
             + "Example: " + COMMAND_WORD + " 1 2";
 
     public static final String MESSAGE_DELETE_PEOPLE_SUCCESS = "Deleted people: %1$s";

--- a/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
@@ -24,7 +24,7 @@ public class DeleteTaskCommand extends Command {
             + "Parameters: INDEX [MORE_INDICES] (must be positive integers)\n"
             + "Example: " + COMMAND_WORD + " 1 2";
 
-    public static final String MESSAGE_DELETE_TASKS_SUCCESS = "Deleted tasks: %1$s";
+    public static final String MESSAGE_SUCCESS = "Deleted tasks: %1$s";
 
     private final Index[] targetIndices;
 
@@ -54,7 +54,7 @@ public class DeleteTaskCommand extends Command {
 
         Arrays.stream(tasksToDelete).forEach(model::deleteTask);
 
-        return new CommandResult(String.format(MESSAGE_DELETE_TASKS_SUCCESS, Messages.format(tasksToDelete)));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(tasksToDelete)));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
@@ -21,7 +21,7 @@ public class DeleteTaskCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the tasks identified by the index numbers used in the displayed task list.\n"
-            + "Parameters: INDEX [MORE_INDICES] (must be distinct positive integers)\n"
+            + "Parameters: INDEX [MORE_INDICES] (must be positive integers)\n"
             + "Example: " + COMMAND_WORD + " 1 2";
 
     public static final String MESSAGE_DELETE_TASKS_SUCCESS = "Deleted tasks: %1$s";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -44,7 +44,7 @@ public class EditCommand extends Command {
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
 
-    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
+    public static final String MESSAGE_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
 
@@ -81,7 +81,7 @@ public class EditCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(editedPerson)));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/EditTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditTaskCommand.java
@@ -43,7 +43,7 @@ public class EditTaskCommand extends Command {
             + PREFIX_TASK_PRIORITY + "HIGH "
             + PREFIX_TASK_DEADLINE + "30-03-2024 10:00";
 
-    public static final String MESSAGE_EDIT_TASK_SUCCESS = "Edited Task: %1$s";
+    public static final String MESSAGE_SUCCESS = "Edited Task: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_TASK = "Duplicate task exists in the task list.";
 
@@ -81,7 +81,7 @@ public class EditTaskCommand extends Command {
         // Updates the task list.
         model.setTask(taskToEdit, editedTask);
 
-        return new CommandResult(String.format(MESSAGE_EDIT_TASK_SUCCESS, Messages.format(taskToEdit)));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(taskToEdit)));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/MarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkTaskCommand.java
@@ -24,7 +24,7 @@ public class MarkTaskCommand extends Command {
             + "Parameter: INDEX [MORE_INDICES] (must be positive integers) \n"
             + "Example: " + COMMAND_WORD + " 1 2";
 
-    public static final String MESSAGE_MARK_TASK_SUCCESS = "Tasks have been marked as done: %1$s";
+    public static final String MESSAGE_SUCCESS = "Tasks have been marked as done: %1$s";
 
     private final Index[] targetIndices;
 
@@ -55,7 +55,7 @@ public class MarkTaskCommand extends Command {
             model.setTask(taskToMark, editedTask);
         });
 
-        return new CommandResult(String.format(MESSAGE_MARK_TASK_SUCCESS, Messages.format(tasksToMark)));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(tasksToMark)));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/MarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkTaskCommand.java
@@ -21,7 +21,7 @@ public class MarkTaskCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Marks the tasks identified by the index numbers used in the displayed task list as done. \n"
-            + "Parameter: INDEX [MORE_INDICES] (must be distinct positive integers) \n"
+            + "Parameter: INDEX [MORE_INDICES] (must be positive integers) \n"
             + "Example: " + COMMAND_WORD + " 1 2";
 
     public static final String MESSAGE_MARK_TASK_SUCCESS = "Tasks have been marked as done: %1$s";

--- a/src/main/java/seedu/address/logic/commands/UnassignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnassignCommand.java
@@ -29,7 +29,7 @@ public class UnassignCommand extends Command {
             + "by the index numbers used in the last person listing. "
             + "Does nothing if the task not assigned to a person.\n"
             + "Parameters: TASK_INDEX (must be a positive integer) "
-            + "to/ PERSON_INDEX [MORE_PERSON_INDICES] (must be distinct positive integers)\n"
+            + "to/ PERSON_INDEX [MORE_PERSON_INDICES] (must be positive integers)\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + "to/ 1 2";
 

--- a/src/main/java/seedu/address/logic/commands/UnmarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkTaskCommand.java
@@ -23,7 +23,7 @@ public class UnmarkTaskCommand extends Command {
             + ": Marks the tasks identified by the index numbers used in the displayed task list as undone. \n"
             + "Parameter: INDEX [MORE_INDICES] (must be positive integers) \n"
             + "Example: " + COMMAND_WORD + " 1 2";
-    public static final String MESSAGE_UNMARK_TASK_SUCCESS = "Tasks have been marked as undone: %1$s";
+    public static final String MESSAGE_SUCCESS = "Tasks have been marked as undone: %1$s";
 
     private final Index[] targetIndices;
 
@@ -54,7 +54,7 @@ public class UnmarkTaskCommand extends Command {
             model.setTask(taskToUnmark, editedTask);
         });
 
-        return new CommandResult(String.format(MESSAGE_UNMARK_TASK_SUCCESS, Messages.format(tasksToUnmark)));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(tasksToUnmark)));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/UnmarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkTaskCommand.java
@@ -21,7 +21,7 @@ public class UnmarkTaskCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Marks the tasks identified by the index numbers used in the displayed task list as undone. \n"
-            + "Parameter: INDEX [MORE_INDICES] (must be distinct positive integers) \n"
+            + "Parameter: INDEX [MORE_INDICES] (must be positive integers) \n"
             + "Example: " + COMMAND_WORD + " 1 2";
     public static final String MESSAGE_UNMARK_TASK_SUCCESS = "Tasks have been marked as undone: %1$s";
 

--- a/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
@@ -35,7 +35,7 @@ public class DeleteTaskCommandTest {
         Task taskToDelete = model.getTaskList().getSerializeTaskList().get(INDEX_FIRST.getZeroBased());
         DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(new Index[] { INDEX_FIRST });
 
-        String expectedMessage = String.format(DeleteTaskCommand.MESSAGE_DELETE_TASKS_SUCCESS,
+        String expectedMessage = String.format(DeleteTaskCommand.MESSAGE_SUCCESS,
                 Messages.format(taskToDelete));
 
         ModelManager expectedModel = new ModelManager(
@@ -54,7 +54,7 @@ public class DeleteTaskCommandTest {
 
         DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(new Index[] { INDEX_FIRST, INDEX_SECOND });
 
-        String expectedMessage = String.format(DeleteTaskCommand.MESSAGE_DELETE_TASKS_SUCCESS,
+        String expectedMessage = String.format(DeleteTaskCommand.MESSAGE_SUCCESS,
                 Messages.format(tasksToDelete));
 
         ModelManager expectedModel = new ModelManager(
@@ -70,7 +70,7 @@ public class DeleteTaskCommandTest {
         Task taskToDelete = model.getTaskList().getSerializeTaskList().get(INDEX_FIRST.getZeroBased());
         DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(new Index[] { INDEX_FIRST, INDEX_FIRST });
 
-        String expectedMessage = String.format(DeleteTaskCommand.MESSAGE_DELETE_TASKS_SUCCESS,
+        String expectedMessage = String.format(DeleteTaskCommand.MESSAGE_SUCCESS,
                 Messages.format(taskToDelete));
 
         ModelManager expectedModel = new ModelManager(

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -41,7 +41,7 @@ public class EditCommandTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST, descriptor);
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        String expectedMessage = String.format(EditCommand.MESSAGE_SUCCESS, Messages.format(editedPerson));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
                 new TaskList(), new UserPrefs());
@@ -63,7 +63,7 @@ public class EditCommandTest {
                 .withPhone(VALID_PHONE_BOB).build();
         EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS,
+        String expectedMessage = String.format(EditCommand.MESSAGE_SUCCESS,
                 Messages.format(editedPerson));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
@@ -78,7 +78,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(INDEX_FIRST, new EditPersonDescriptor());
         Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST.getZeroBased());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS,
+        String expectedMessage = String.format(EditCommand.MESSAGE_SUCCESS,
                 Messages.format(editedPerson));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
@@ -96,7 +96,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(INDEX_FIRST,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS,
+        String expectedMessage = String.format(EditCommand.MESSAGE_SUCCESS,
                 Messages.format(editedPerson));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),

--- a/src/test/java/seedu/address/logic/commands/EditTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditTaskCommandTest.java
@@ -33,7 +33,7 @@ public class EditTaskCommandTest {
         EditTaskDescriptor descriptor = new EditTaskDescriptorBuilder(editedTask).build();
         EditTaskCommand editTaskCommand = new EditTaskCommand(INDEX_FIRST, descriptor);
 
-        String expectedMessage = String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS,
+        String expectedMessage = String.format(EditTaskCommand.MESSAGE_SUCCESS,
                 Messages.format(target));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
@@ -56,7 +56,7 @@ public class EditTaskCommandTest {
                 .withPriority("medium").build();
         EditTaskCommand editTaskCommand = new EditTaskCommand(indexLastTask, descriptor);
 
-        String expectedMessage = String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS,
+        String expectedMessage = String.format(EditTaskCommand.MESSAGE_SUCCESS,
                 Messages.format(lastTask));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
@@ -71,7 +71,7 @@ public class EditTaskCommandTest {
         EditTaskCommand editTaskCommand = new EditTaskCommand(INDEX_FIRST, new EditTaskDescriptor());
         Task editedTask = model.getFilteredTaskList().get(INDEX_FIRST.getZeroBased());
 
-        String expectedMessage = String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS,
+        String expectedMessage = String.format(EditTaskCommand.MESSAGE_SUCCESS,
                 Messages.format(editedTask));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),

--- a/src/test/java/seedu/address/logic/commands/MarkTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkTaskCommandTest.java
@@ -37,7 +37,7 @@ public class MarkTaskCommandTest {
         Task taskToMark = model.getTaskList().getSerializeTaskList().get(INDEX_FIRST.getZeroBased());
         MarkTaskCommand markTaskCommand = new MarkTaskCommand(new Index[] { INDEX_FIRST });
 
-        String expectedMessage = String.format(MarkTaskCommand.MESSAGE_MARK_TASK_SUCCESS,
+        String expectedMessage = String.format(MarkTaskCommand.MESSAGE_SUCCESS,
                 Messages.format(taskToMark));
 
         ModelManager expectedModel = new ModelManager(
@@ -59,7 +59,7 @@ public class MarkTaskCommandTest {
 
         MarkTaskCommand markTaskCommand = new MarkTaskCommand(new Index[] { INDEX_FIRST, INDEX_SECOND });
 
-        String expectedMessage = String.format(MarkTaskCommand.MESSAGE_MARK_TASK_SUCCESS,
+        String expectedMessage = String.format(MarkTaskCommand.MESSAGE_SUCCESS,
                 Messages.format(tasksToMark));
 
         ModelManager expectedModel = new ModelManager(
@@ -82,7 +82,7 @@ public class MarkTaskCommandTest {
         Task taskToMark = model.getTaskList().getSerializeTaskList().get(INDEX_FIRST.getZeroBased());
         MarkTaskCommand markTaskCommand = new MarkTaskCommand(new Index[] { INDEX_FIRST, INDEX_FIRST });
 
-        String expectedMessage = String.format(MarkTaskCommand.MESSAGE_MARK_TASK_SUCCESS,
+        String expectedMessage = String.format(MarkTaskCommand.MESSAGE_SUCCESS,
                 Messages.format(taskToMark));
 
         ModelManager expectedModel = new ModelManager(
@@ -137,7 +137,7 @@ public class MarkTaskCommandTest {
         Index noDeadlineTask = Index.fromOneBased(model.getTaskList().getSerializeTaskList().size());
         MarkTaskCommand markTaskCommand = new MarkTaskCommand(new Index[] { noDeadlineTask });
 
-        String expectedMessage = String.format(MarkTaskCommand.MESSAGE_MARK_TASK_SUCCESS,
+        String expectedMessage = String.format(MarkTaskCommand.MESSAGE_SUCCESS,
                 Messages.format(taskWithoutDeadline));
 
         ModelManager expectedModel = new ModelManager(new AddressBook(), model.getTaskList(), new UserPrefs());
@@ -155,7 +155,7 @@ public class MarkTaskCommandTest {
         Index noDeadlineTask = Index.fromOneBased(model.getTaskList().getSerializeTaskList().size());
         MarkTaskCommand markTaskCommand = new MarkTaskCommand(new Index[] { noDeadlineTask });
 
-        String expectedMessage = String.format(MarkTaskCommand.MESSAGE_MARK_TASK_SUCCESS,
+        String expectedMessage = String.format(MarkTaskCommand.MESSAGE_SUCCESS,
                 Messages.format(taskWithDeadline));
 
         ModelManager expectedModel = new ModelManager(new AddressBook(), model.getTaskList(), new UserPrefs());

--- a/src/test/java/seedu/address/logic/commands/UnmarkTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnmarkTaskCommandTest.java
@@ -37,7 +37,7 @@ public class UnmarkTaskCommandTest {
         Task taskToUnmark = model.getTaskList().getSerializeTaskList().get(INDEX_FIRST.getZeroBased());
         UnmarkTaskCommand unmarkTaskCommand = new UnmarkTaskCommand(new Index[] { INDEX_FIRST });
 
-        String expectedMessage = String.format(UnmarkTaskCommand.MESSAGE_UNMARK_TASK_SUCCESS,
+        String expectedMessage = String.format(UnmarkTaskCommand.MESSAGE_SUCCESS,
                 Messages.format(taskToUnmark));
 
         ModelManager expectedModel = new ModelManager(
@@ -58,7 +58,7 @@ public class UnmarkTaskCommandTest {
 
         UnmarkTaskCommand unmarkTaskCommand = new UnmarkTaskCommand(new Index[] { INDEX_FIRST, INDEX_SECOND });
 
-        String expectedMessage = String.format(UnmarkTaskCommand.MESSAGE_UNMARK_TASK_SUCCESS,
+        String expectedMessage = String.format(UnmarkTaskCommand.MESSAGE_SUCCESS,
                 Messages.format(tasksToUnmark));
 
         ModelManager expectedModel = new ModelManager(
@@ -78,7 +78,7 @@ public class UnmarkTaskCommandTest {
         Task taskToUnmark = model.getTaskList().getSerializeTaskList().get(INDEX_FIRST.getZeroBased());
         UnmarkTaskCommand unmarkTaskCommand = new UnmarkTaskCommand(new Index[] { INDEX_FIRST, INDEX_FIRST });
 
-        String expectedMessage = String.format(UnmarkTaskCommand.MESSAGE_UNMARK_TASK_SUCCESS,
+        String expectedMessage = String.format(UnmarkTaskCommand.MESSAGE_SUCCESS,
                 Messages.format(taskToUnmark));
 
         ModelManager expectedModel = new ModelManager(
@@ -131,7 +131,7 @@ public class UnmarkTaskCommandTest {
         Index noDeadlineTask = Index.fromOneBased(model.getTaskList().getSerializeTaskList().size());
         UnmarkTaskCommand unmarkTaskCommand = new UnmarkTaskCommand(new Index[] { noDeadlineTask });
 
-        String expectedMessage = String.format(UnmarkTaskCommand.MESSAGE_UNMARK_TASK_SUCCESS,
+        String expectedMessage = String.format(UnmarkTaskCommand.MESSAGE_SUCCESS,
                 Messages.format(taskWithoutDeadline));
 
         ModelManager expectedModel = new ModelManager(new AddressBook(), model.getTaskList(), new UserPrefs());
@@ -149,7 +149,7 @@ public class UnmarkTaskCommandTest {
         Index deadlineTask = Index.fromOneBased(model.getTaskList().getSerializeTaskList().size());
         UnmarkTaskCommand unmarkTaskCommand = new UnmarkTaskCommand(new Index[] { deadlineTask });
 
-        String expectedMessage = String.format(UnmarkTaskCommand.MESSAGE_UNMARK_TASK_SUCCESS,
+        String expectedMessage = String.format(UnmarkTaskCommand.MESSAGE_SUCCESS,
                 Messages.format(taskWithDeadline));
 
         ModelManager expectedModel = new ModelManager(new AddressBook(), model.getTaskList(), new UserPrefs());


### PR DESCRIPTION
This PR mainly tweaks the usage message of commands for which mass ops is supported. The usage messages currently state that the provided indices must be distinct, yet the mass ops commands are actually able to remove duplicate indices. As such, the distinctness requirement in the usage messages will be removed, widening the scope of these messages.

Additionally, the success message string constant for each command are also renamed to be consistent with each other, as an attempt to improve code quality. Note that this just changes the names of several variables internally, and does not change any text in the UI at all.